### PR TITLE
Make parent handle SIGCHLD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore generated executable
+3snake
+
+# Ignore generated object files
+*.o


### PR DESCRIPTION
When initially running 3snake on my system, the send() call to netlink failed to connect.
This caused the child to fatal(), but the parent was left sleeping. I believe the parent should handle the SIGCHLD signal and exit appropriately.

Additionally, if the child exited with an actual error (e.g. a division by zero or SIGSEGV), be sure to reflect this to the user. Comments appreciated.